### PR TITLE
Drill Strategy Data Update

### DIFF
--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -22,8 +22,7 @@ export class Board{
     private solution: string[][];
     private solutionString: string;
     private strategies: boolean[];
-    private moveStrategies: boolean[][]; // stores drillStrategies for each move
-    private drills: boolean[];
+    private moveStrategies: boolean[][]; // stores last time strategy can be used as drill or -1 if never
     private difficulty: number;
     private solver: Solver;
     private givensCount: number;
@@ -48,7 +47,6 @@ export class Board{
         this.board = getBoardArray(board);
 
         this.strategies = new Array(StrategyEnum.COUNT).fill(false);
-        this.drills = new Array(StrategyEnum.COUNT).fill(false);
         this.moveStrategies = new Array();
 
         if (algorithm === undefined) {
@@ -61,7 +59,6 @@ export class Board{
         this.givensCount = this.solver.getPlacedCount();
 
         this.solve();
-        this.drills = this.moveStrategies[0];
         this.setDifficulty();
     }
 
@@ -103,14 +100,6 @@ export class Board{
      */
     public getDifficulty():number {
         return this.difficulty;
-    }
-
-    /**
-     * Get drills
-     * @returns drills
-     */
-    public getDrills():boolean[] {
-        return this.drills;
     }
 
     /**

--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -22,7 +22,7 @@ export class Board{
     private solution: string[][];
     private solutionString: string;
     private strategies: boolean[];
-    private moveStrategies: number[]; // stores last time strategy can be used as drill or -1 if never
+    private drills: number[]; // stores last time strategy can be used as drill or -1 if never
     private difficulty: number;
     private solver: Solver;
     private givensCount: number;
@@ -47,7 +47,7 @@ export class Board{
         this.board = getBoardArray(board);
 
         this.strategies = new Array(StrategyEnum.COUNT).fill(false);
-        this.moveStrategies = new Array(StrategyEnum.HIDDEN_QUADRUPLET-StrategyEnum.NAKED_SINGLE+1).fill(-1);
+        this.drills = new Array(StrategyEnum.HIDDEN_QUADRUPLET-StrategyEnum.NAKED_SINGLE+1).fill(-1);
 
         if (algorithm === undefined) {
             this.solver = new Solver(this.board);
@@ -111,11 +111,11 @@ export class Board{
     }
 
     /**
-     * Get moveStrategies
-     * @returns moveStrategies
+     * Get drills
+     * @returns drills
      */
-    public getMoveStrategies():number[] {
-        return this.moveStrategies;
+    public getDrills():number[] {
+        return this.drills;
     }
 
     /**
@@ -217,11 +217,11 @@ export class Board{
             // Records what strategies were used for each move
             let move:boolean[] = this.getDrillStrategies();
             // Moves are classified as one per value insertion (so 80 is last move)
-            // moveStrategies array index 0 is naked single and index 9 is hidden quadruplet
+            // drills array index 0 is naked single and index 9 is hidden quadruplet
             // each index stores the last time the strategy can be used as a drill or -1 if never
             for (let i:number = 0; i < move.length; i++) {
                 if (move[i]) {
-                    this.moveStrategies[i] = this.solver.getPlacedCount();
+                    this.drills[i] = this.solver.getPlacedCount();
                 }
             }
 

--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -22,7 +22,7 @@ export class Board{
     private solution: string[][];
     private solutionString: string;
     private strategies: boolean[];
-    private moveStrategies: boolean[][]; // stores last time strategy can be used as drill or -1 if never
+    private moveStrategies: number[]; // stores last time strategy can be used as drill or -1 if never
     private difficulty: number;
     private solver: Solver;
     private givensCount: number;
@@ -47,7 +47,7 @@ export class Board{
         this.board = getBoardArray(board);
 
         this.strategies = new Array(StrategyEnum.COUNT).fill(false);
-        this.moveStrategies = new Array();
+        this.moveStrategies = new Array(StrategyEnum.HIDDEN_QUADRUPLET-StrategyEnum.NAKED_SINGLE+1).fill(-1);
 
         if (algorithm === undefined) {
             this.solver = new Solver(this.board);
@@ -114,7 +114,7 @@ export class Board{
      * Get moveStrategies
      * @returns moveStrategies
      */
-    public getMoveStrategies():boolean[][] {
+    public getMoveStrategies():number[] {
         return this.moveStrategies;
     }
 
@@ -216,15 +216,12 @@ export class Board{
 
             // Records what strategies were used for each move
             let move:boolean[] = this.getDrillStrategies();
-            // Moves are classified as one per value insertion so check if move has already started and if so add to it
-            // moveStrategies array index 0 is for when placedCount == givensCount and 1 is givensCount + 1 and so on
-            let moveIndex:number = this.solver.getPlacedCount() - this.givensCount;
-            if (moveIndex >= this.moveStrategies.length) {
-                this.moveStrategies.push(move);
-            }
-            else {
-                for (let i:number = 0; i < move.length; i++) {
-                    this.moveStrategies[moveIndex][i] = this.moveStrategies[moveIndex][i] || move[i];
+            // Moves are classified as one per value insertion (so 80 is last move)
+            // moveStrategies array index 0 is naked single and index 9 is hidden quadruplet
+            // each index stores the last time the strategy can be used as a drill or -1 if never
+            for (let i:number = 0; i < move.length; i++) {
+                if (move[i]) {
+                    this.moveStrategies[i] = this.solver.getPlacedCount();
                 }
             }
 

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -146,16 +146,6 @@ describe("solve Boards", () => {
 
     it('should solve single naked single', () => {
         expect(singleNakedSingle.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
-        /*let drills:boolean[] = singleNakedSingle.getDrills();
-        for (let i:StrategyEnum = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
-            // subtracted naked single cause it's the first strategy once amend/simplify are removed by getDrillStrategies()
-            if (i === StrategyEnum.NAKED_SINGLE) {
-                expect(drills[i- StrategyEnum.NAKED_SINGLE]).toBeTruthy();
-            }
-            else {
-                expect(drills[i- StrategyEnum.NAKED_SINGLE]).toBeFalsy();
-            }
-        }*/
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
             if (i === StrategyEnum.NAKED_SINGLE || i === StrategyEnum.AMEND_NOTES) {
                 expect(singleNakedSingle.getStrategies()[i]).toBeTruthy();

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -146,7 +146,7 @@ describe("solve Boards", () => {
 
     it('should solve single naked single', () => {
         expect(singleNakedSingle.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
-        let drills:boolean[] = singleNakedSingle.getDrills();
+        /*let drills:boolean[] = singleNakedSingle.getDrills();
         for (let i:StrategyEnum = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
             // subtracted naked single cause it's the first strategy once amend/simplify are removed by getDrillStrategies()
             if (i === StrategyEnum.NAKED_SINGLE) {
@@ -155,7 +155,7 @@ describe("solve Boards", () => {
             else {
                 expect(drills[i- StrategyEnum.NAKED_SINGLE]).toBeFalsy();
             }
-        }
+        }*/
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
             if (i === StrategyEnum.NAKED_SINGLE || i === StrategyEnum.AMEND_NOTES) {
                 expect(singleNakedSingle.getStrategies()[i]).toBeTruthy();

--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ Boolean array representing which strategies were used to solve the puzzle in fol
 - 7: POINTING_TRIPLET,
 - 8: NAKED_QUADRUPLET,
 - 9: HIDDEN_QUADRUPLET,
-## moveStrategies
-- 2D boolean array representing which strategies can reasonably be used as drills at each "move".
-- A move is defined as the puzzle when it has a certain number of cells filled in (so index 0 just has givens and last index has all cells filled in).
+## drills
+- 1D number array representing last time strategy can be reasonably used as drill or -1 if it can't be used as a drill
+- Each index is defined as the puzzle when it has a certain number of cells filled in (so index 30 has 30 cells filled in including givens).
 - Reasonably is defined as to mean removing strategies if they overlap with their prereqs (i.e. if a naked pair is made up of two naked singles the pair will be excluded) and not counting a strategy if multiple instances of it are present so their is only one correct answer.
-- The same boolean index to strategy mapping as puzzleStrategies is used.
+- The same number index to strategy mapping as puzzleStrategies is used.
 # Developer Tools
 
 **Note**: This project is using Bun. This means WSL or a linux/mac machine is required to run. 

--- a/lib/PuzzleData.ts
+++ b/lib/PuzzleData.ts
@@ -13,6 +13,6 @@ export function getPuzzleData(board: string): JSON {
         "difficulty": boardObj.getDifficulty(),
         "givensCount": boardObj.getGivensCount(),
         "puzzleStrategies": boardObj.getStrategies().slice(StrategyEnum.NAKED_SINGLE, StrategyEnum.HIDDEN_QUADRUPLET + 1), // excludes amend/simplify notes strategies and everything past hidden quadruplet
-        "moveStrategies": boardObj.getMoveStrategies() // excludes amend/simplify notes strategies and everything past hidden quadruplet
+        "drills": boardObj.getDrills() // index of last time strategy can be used as drill or -1 if never (e.g. if on last move then 80 cause 80 cells filled in on last move), excludes amend/simplify notes strategies and everything past hidden quadruplet
     };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sudokuru",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "This is the Sudokuru package.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Checklist for completing pull request:
- [x] Verify that package version is incremented. You can do this with the command ```npm version [major|minor|patch]```
- [x] Verify that any unit tests for new functionality are created and functional.
- [x] If needed, update the Readme

Updated the drills strategies (now called drills, formerly called moveStrategies) returned in getPuzzleData to be a simple 1D number array storing the last time the strategies can be used as drills or -1 if never. Also, got rid of the old drills Board class field.