### PR TITLE
Road to V4: Implement Obvious Single Strategy

### DIFF
--- a/V4/PLAN.md
+++ b/V4/PLAN.md
@@ -576,14 +576,14 @@ For each strategy:
 | ☑      | Strategy implementation PR checklist         | Strategy has sufficient docs/tests/etc link to example PRs         | https://github.com/Sudokuru/Sudokuru/pull/114 |
 | ☑      | Implement wrong value                        | Strategy module + tests match docs                                 | https://github.com/Sudokuru/Sudokuru/pull/114 |
 | ☑      | Implement amend notes                        | Strategy module + tests match docs                                 | https://github.com/Sudokuru/Sudokuru/pull/115 |
-| ☐      | Implement obvious single                     | Strategy module + tests match docs                                 | —       |
+| ☑      | Implement obvious single                     | Strategy module + tests match docs                                 | https://github.com/Sudokuru/Sudokuru/pull/116 |
+| ☐      | `SudokuVision` interface                     | Documented and implemented                                         | —       |
+| ☐      | Queue-based SudokuVision impl                | Deterministic fallback scan; tests                                 | —       |
 | ☐      | `getHint`                                    | Deterministic; staged hints; strategy ordering; tests              | —       |
 | ☐      | `getAllHints`                                | Deterministic; uses strategy set; tests                            | —       |
 | ☐      | `applyHint`                                  | Pure; correct diffs; tests                                         | —       |
 | ☐      | Difficulty module                            | `getRawDifficulty` returns stable number; tests                    | —       |
 | ☐      | `getGameDifficulty` (placeholder ok)         | Returns `GameDifficulty`; boundaries documented                    | —       |
-| ☐      | `SudokuVision` interface                     | Documented and implemented                                         | —       |
-| ☐      | Queue-based SudokuVision impl                | Deterministic fallback scan; tests                                 | —       |
 | ☐      | `getGivensCount`                             | Correct count; tests                                               | —       |
 | ☐      | `getSudokuData`                              | Produces SudokuData; drill loop stable; tests                      | —       |
 | ☐      | Simplify notes doc                           | Example + approval                                                 | —       |

--- a/V4/docs/OBVIOUS_SINGLE_FRONTEND_DEMO.ts
+++ b/V4/docs/OBVIOUS_SINGLE_FRONTEND_DEMO.ts
@@ -93,7 +93,7 @@ const SIMPLIFYING_SOURCE_PUZZLE_NUMBERS: SudokuNumber[][] = [
   [0, 0, 0, 0, 0, 1, 5, 0, 0],
 ];
 
-const obviousSingleNoteCell: NoteCellWithLocation = {
+export const obviousSingleNoteCell: NoteCellWithLocation = {
   r: 1,
   c: 0,
   type: "note",
@@ -107,7 +107,7 @@ const obviousSingleValueCell: ValueCellWithLocation = {
   value: 2,
 };
 
-const simplifyingObviousSingleNoteCell: NoteCellWithLocation = {
+export const simplifyingObviousSingleNoteCell: NoteCellWithLocation = {
   r: 5,
   c: 1,
   type: "note",

--- a/V4/obviousSingle.ts
+++ b/V4/obviousSingle.ts
@@ -128,7 +128,7 @@ function getRemovalStages(
 }
 
 /**
- * Returns a staged hint when the targeted note cell has exactly one candidate remaining.
+ * Returns a staged hint when the targeted note cell's sole candidate matches the solution.
  */
 export function getObviousSingleHint(
   puzzle: readonly (readonly CellProps[])[],
@@ -142,6 +142,11 @@ export function getObviousSingleHint(
   }
 
   const value = target.notes[0];
+
+  if (value !== solution[target.r][target.c]) {
+    return null;
+  }
+
   const targetValue: ValueCellWithLocation = {
     r: target.r,
     c: target.c,

--- a/V4/obviousSingle.ts
+++ b/V4/obviousSingle.ts
@@ -40,7 +40,7 @@ function getNewNoteRemovals(
 
     const noteCell = getNoteCell(puzzle, location);
 
-    if (!noteCell || !noteCell.notes.includes(value)) {
+    if (!noteCell?.notes.includes(value)) {
       continue;
     }
 
@@ -137,7 +137,7 @@ export function getObviousSingleHint(
 ): Hint | null {
   const target = getNoteCell(puzzle, locationToCheck);
 
-  if (!target || target.notes.length !== 1) {
+  if (target?.notes.length !== 1) {
     return null;
   }
 

--- a/V4/obviousSingle.ts
+++ b/V4/obviousSingle.ts
@@ -1,0 +1,15 @@
+import type {
+  CellLocation,
+  CellProps,
+  Hint,
+  SudokuNumber,
+} from "./Types";
+
+/**
+ * Returns a staged hint when the targeted note cell has exactly one candidate remaining.
+ */
+export declare function getObviousSingleHint(
+  puzzle: readonly (readonly CellProps[])[],
+  solution: readonly (readonly SudokuNumber[])[],
+  locationToCheck: CellLocation
+): Hint | null;

--- a/V4/obviousSingle.ts
+++ b/V4/obviousSingle.ts
@@ -1,15 +1,173 @@
+import { getNoteCell, locationsEqual } from "./cellLocations";
+import { getUnitDescription, getUnitLocations } from "./units";
+import { UNIT_PRECEDENCE } from "./Types";
 import type {
   CellLocation,
   CellProps,
+  HighlightedCell,
+  HighlightedNote,
   Hint,
+  HintStage,
+  NoteCellWithLocation,
   SudokuNumber,
+  Unit,
+  ValueCellWithLocation,
 } from "./Types";
+
+const INTRODUCTION_TEXT =
+  "An obvious single is a cell with only one note remaining.";
+
+/**
+ * Returns note-removal actions that were not already handled by an earlier unit.
+ */
+function getNewNoteRemovals(
+  puzzle: readonly (readonly CellProps[])[],
+  target: NoteCellWithLocation,
+  value: SudokuNumber,
+  unitLocations: readonly CellLocation[],
+  removedLocations: readonly CellLocation[]
+): NoteCellWithLocation[] {
+  const noteRemovals: NoteCellWithLocation[] = [];
+
+  for (const location of unitLocations) {
+    const alreadyRemoved = removedLocations.some((removedLocation) =>
+      locationsEqual(location, removedLocation)
+    );
+
+    if (locationsEqual(location, target) || alreadyRemoved) {
+      continue;
+    }
+
+    const noteCell = getNoteCell(puzzle, location);
+
+    if (!noteCell || !noteCell.notes.includes(value)) {
+      continue;
+    }
+
+    noteRemovals.push({ ...noteCell, notes: [value] });
+  }
+
+  return noteRemovals;
+}
+
+/**
+ * Builds one exact row, column, or box note-simplification stage.
+ */
+function getRemovalStage(
+  targetValue: ValueCellWithLocation,
+  unit: Unit,
+  unitLocations: readonly CellLocation[],
+  noteRemovals: readonly NoteCellWithLocation[]
+): HintStage {
+  const highlightCells: HighlightedCell[] = [];
+  const highlightNotes: HighlightedNote[] = [];
+
+  for (const location of unitLocations) {
+    if (!locationsEqual(location, targetValue)) {
+      highlightCells.push({ location, highlightType: "focus" });
+    }
+  }
+
+  highlightCells.push({ location: targetValue, highlightType: "basis" });
+
+  for (const { r, c } of noteRemovals) {
+    highlightNotes.push({
+      location: { r, c },
+      value: targetValue.value,
+      highlightType: "removal",
+    });
+  }
+
+  return {
+    removeNotes: [...noteRemovals],
+    highlightCells,
+    highlightNotes,
+    text: `Remove note ${targetValue.value} from the other cells in ${getUnitDescription(
+      targetValue,
+      unit
+    )}.`,
+  };
+}
+
+/**
+ * Builds deterministic row, column, and box simplification stages.
+ */
+function getRemovalStages(
+  puzzle: readonly (readonly CellProps[])[],
+  target: NoteCellWithLocation,
+  targetValue: ValueCellWithLocation
+): HintStage[] {
+  const stages: HintStage[] = [];
+  const removedLocations: CellLocation[] = [];
+  const size = puzzle.length;
+
+  for (const unit of UNIT_PRECEDENCE) {
+    const unitLocations = getUnitLocations(target, unit, size);
+    const noteRemovals = getNewNoteRemovals(
+      puzzle,
+      target,
+      targetValue.value,
+      unitLocations,
+      removedLocations
+    );
+
+    if (noteRemovals.length === 0) {
+      continue;
+    }
+
+    for (const { r, c } of noteRemovals) {
+      removedLocations.push({ r, c });
+    }
+
+    stages.push(
+      getRemovalStage(targetValue, unit, unitLocations, noteRemovals)
+    );
+  }
+
+  return stages;
+}
 
 /**
  * Returns a staged hint when the targeted note cell has exactly one candidate remaining.
  */
-export declare function getObviousSingleHint(
+export function getObviousSingleHint(
   puzzle: readonly (readonly CellProps[])[],
   solution: readonly (readonly SudokuNumber[])[],
   locationToCheck: CellLocation
-): Hint | null;
+): Hint | null {
+  const target = getNoteCell(puzzle, locationToCheck);
+
+  if (!target || target.notes.length !== 1) {
+    return null;
+  }
+
+  const value = target.notes[0];
+  const targetValue: ValueCellWithLocation = {
+    r: target.r,
+    c: target.c,
+    type: "value",
+    value,
+  };
+  const row = target.r + 1;
+  const column = target.c + 1;
+  const removalStages = getRemovalStages(puzzle, target, targetValue);
+
+  return {
+    strategy: "OBVIOUS_SINGLE",
+    stages: [
+      { text: INTRODUCTION_TEXT },
+      {
+        highlightCells: [{ location: target, highlightType: "focus" }],
+        text: `Row ${row}, column ${column} has only one note remaining: ${value}.`,
+      },
+      {
+        placeValues: [targetValue],
+        highlightCells: [
+          { location: targetValue, highlightType: "placement" },
+        ],
+        text: `Place ${value} in row ${row}, column ${column}.`,
+      },
+      ...removalStages,
+    ],
+  };
+}

--- a/V4/tests/unit/obviousSingle.test.ts
+++ b/V4/tests/unit/obviousSingle.test.ts
@@ -263,6 +263,26 @@ describe("getObviousSingleHint", () => {
     );
   });
 
+  it("returns null when the sole candidate does not match the solution", () => {
+    const incorrectTarget: NoteCellWithLocation = {
+      r: TARGET.r,
+      c: TARGET.c,
+      type: "note",
+      notes: [4],
+    };
+    const puzzle = withNotes(createEmptyPuzzle(BOARD_SIZE), [
+      incorrectTarget,
+    ]);
+
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      puzzle,
+      SOLUTION,
+      incorrectTarget,
+      null
+    );
+  });
+
   it.each<{
     label: string;
     target: CellWithLocation;

--- a/V4/tests/unit/obviousSingle.test.ts
+++ b/V4/tests/unit/obviousSingle.test.ts
@@ -1,0 +1,384 @@
+import type {
+  CellWithLocation,
+  Hint,
+  HintStage,
+  NoteCellWithLocation,
+  ValueCellWithLocation,
+} from "../../Types";
+import { getObviousSingleHint } from "../../obviousSingle";
+import { expectHintWithoutMutation } from "../utils/assertions";
+import { createEmptyPuzzle } from "../utils/puzzleFactories";
+import { SOLVED_TEST_BOARDS } from "../utils/testBoards";
+import { withNotes, withValues } from "../utils/withCells";
+
+const BOARD_SIZE = 6;
+const SOLUTION = SOLVED_TEST_BOARDS[BOARD_SIZE];
+
+// A 6x6 board exercises the supported rectangular 2x3 box layout while
+// keeping every expected row, column, and box location easy to audit.
+const TARGET: NoteCellWithLocation = {
+  r: 1,
+  c: 1,
+  type: "note",
+  notes: [5],
+};
+
+const TARGET_VALUE = {
+  r: 1,
+  c: 1,
+  type: "value" as const,
+  value: 5,
+};
+
+const INTRODUCTION_STAGE: HintStage = {
+  text: "An obvious single is a cell with only one note remaining.",
+};
+
+const IDENTIFICATION_STAGE: HintStage = {
+  highlightCells: [{ location: TARGET, highlightType: "focus" }],
+  text: "Row 2, column 2 has only one note remaining: 5.",
+};
+
+const PLACEMENT_STAGE: HintStage = {
+  placeValues: [TARGET_VALUE],
+  highlightCells: [{ location: TARGET_VALUE, highlightType: "placement" }],
+  text: "Place 5 in row 2, column 2.",
+};
+
+const ROW_REMOVAL_STAGE: HintStage = {
+  removeNotes: [
+    { r: 1, c: 0, type: "note", notes: [5] },
+    { r: 1, c: 5, type: "note", notes: [5] },
+  ],
+  highlightCells: [
+    { location: { r: 1, c: 0 }, highlightType: "focus" },
+    { location: { r: 1, c: 2 }, highlightType: "focus" },
+    { location: { r: 1, c: 3 }, highlightType: "focus" },
+    { location: { r: 1, c: 4 }, highlightType: "focus" },
+    { location: { r: 1, c: 5 }, highlightType: "focus" },
+    { location: TARGET_VALUE, highlightType: "basis" },
+  ],
+  highlightNotes: [
+    {
+      location: { r: 1, c: 0 },
+      value: 5,
+      highlightType: "removal",
+    },
+    {
+      location: { r: 1, c: 5 },
+      value: 5,
+      highlightType: "removal",
+    },
+  ],
+  text: "Remove note 5 from the other cells in row 2.",
+};
+
+const COLUMN_REMOVAL_STAGE: HintStage = {
+  removeNotes: [
+    { r: 0, c: 1, type: "note", notes: [5] },
+    { r: 5, c: 1, type: "note", notes: [5] },
+  ],
+  highlightCells: [
+    { location: { r: 0, c: 1 }, highlightType: "focus" },
+    { location: { r: 2, c: 1 }, highlightType: "focus" },
+    { location: { r: 3, c: 1 }, highlightType: "focus" },
+    { location: { r: 4, c: 1 }, highlightType: "focus" },
+    { location: { r: 5, c: 1 }, highlightType: "focus" },
+    { location: TARGET_VALUE, highlightType: "basis" },
+  ],
+  highlightNotes: [
+    {
+      location: { r: 0, c: 1 },
+      value: 5,
+      highlightType: "removal",
+    },
+    {
+      location: { r: 5, c: 1 },
+      value: 5,
+      highlightType: "removal",
+    },
+  ],
+  text: "Remove note 5 from the other cells in column 2.",
+};
+
+const BOX_REMOVAL_STAGE: HintStage = {
+  removeNotes: [
+    { r: 0, c: 0, type: "note", notes: [5] },
+    { r: 0, c: 2, type: "note", notes: [5] },
+  ],
+  highlightCells: [
+    { location: { r: 0, c: 0 }, highlightType: "focus" },
+    { location: { r: 0, c: 1 }, highlightType: "focus" },
+    { location: { r: 0, c: 2 }, highlightType: "focus" },
+    { location: { r: 1, c: 0 }, highlightType: "focus" },
+    { location: { r: 1, c: 2 }, highlightType: "focus" },
+    { location: TARGET_VALUE, highlightType: "basis" },
+  ],
+  highlightNotes: [
+    {
+      location: { r: 0, c: 0 },
+      value: 5,
+      highlightType: "removal",
+    },
+    {
+      location: { r: 0, c: 2 },
+      value: 5,
+      highlightType: "removal",
+    },
+  ],
+  text: "Remove note 5 from the other cells in the same box.",
+};
+
+const PLACEMENT_ONLY_HINT: Hint = {
+  strategy: "OBVIOUS_SINGLE",
+  stages: [INTRODUCTION_STAGE, IDENTIFICATION_STAGE, PLACEMENT_STAGE],
+};
+
+const ROW_REMOVAL_HINT: Hint = {
+  strategy: "OBVIOUS_SINGLE",
+  stages: [
+    INTRODUCTION_STAGE,
+    IDENTIFICATION_STAGE,
+    PLACEMENT_STAGE,
+    ROW_REMOVAL_STAGE,
+  ],
+};
+
+const COLUMN_REMOVAL_HINT: Hint = {
+  strategy: "OBVIOUS_SINGLE",
+  stages: [
+    INTRODUCTION_STAGE,
+    IDENTIFICATION_STAGE,
+    PLACEMENT_STAGE,
+    COLUMN_REMOVAL_STAGE,
+  ],
+};
+
+const BOX_REMOVAL_HINT: Hint = {
+  strategy: "OBVIOUS_SINGLE",
+  stages: [
+    INTRODUCTION_STAGE,
+    IDENTIFICATION_STAGE,
+    PLACEMENT_STAGE,
+    BOX_REMOVAL_STAGE,
+  ],
+};
+
+const PRECEDENCE_HINT: Hint = {
+  strategy: "OBVIOUS_SINGLE",
+  stages: [
+    INTRODUCTION_STAGE,
+    IDENTIFICATION_STAGE,
+    PLACEMENT_STAGE,
+    ROW_REMOVAL_STAGE,
+    COLUMN_REMOVAL_STAGE,
+    BOX_REMOVAL_STAGE,
+  ],
+};
+
+const ROW_REMOVAL_INPUTS: readonly NoteCellWithLocation[] = [
+  { r: 1, c: 0, type: "note", notes: [1, 5] },
+  { r: 1, c: 5, type: "note", notes: [5, 6] },
+];
+
+const COLUMN_REMOVAL_INPUTS: readonly NoteCellWithLocation[] = [
+  { r: 0, c: 1, type: "note", notes: [2, 5] },
+  { r: 5, c: 1, type: "note", notes: [3, 5] },
+];
+
+const BOX_REMOVAL_INPUTS: readonly NoteCellWithLocation[] = [
+  { r: 0, c: 0, type: "note", notes: [4, 5] },
+  { r: 0, c: 2, type: "note", notes: [5, 6] },
+];
+
+describe("getObviousSingleHint", () => {
+  it.each<{
+    label: string;
+    peerNotes: readonly NoteCellWithLocation[];
+    expectedHint: Hint;
+  }>([
+    {
+      label: "row",
+      peerNotes: ROW_REMOVAL_INPUTS,
+      expectedHint: ROW_REMOVAL_HINT,
+    },
+    {
+      label: "column",
+      peerNotes: COLUMN_REMOVAL_INPUTS,
+      expectedHint: COLUMN_REMOVAL_HINT,
+    },
+    {
+      label: "rectangular box",
+      peerNotes: BOX_REMOVAL_INPUTS,
+      expectedHint: BOX_REMOVAL_HINT,
+    },
+  ])(
+    "returns the exact isolated $label note-removal stage",
+    ({ peerNotes, expectedHint }) => {
+      const puzzle = withNotes(createEmptyPuzzle(BOARD_SIZE), [
+        TARGET,
+        ...peerNotes,
+      ]);
+
+      expectHintWithoutMutation(
+        getObviousSingleHint,
+        puzzle,
+        SOLUTION,
+        TARGET,
+        expectedHint
+      );
+    }
+  );
+
+  it("uses row, column, then box precedence without removing overlapping notes twice", () => {
+    const puzzle = withNotes(createEmptyPuzzle(BOARD_SIZE), [
+      TARGET,
+      ...BOX_REMOVAL_INPUTS,
+      ...COLUMN_REMOVAL_INPUTS,
+      ...ROW_REMOVAL_INPUTS,
+    ]);
+
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      puzzle,
+      SOLUTION,
+      TARGET,
+      PRECEDENCE_HINT
+    );
+  });
+
+  it("returns a placement-only hint when peer notes do not contain the placed value", () => {
+    const puzzle = withNotes(createEmptyPuzzle(BOARD_SIZE), [
+      TARGET,
+      { r: 1, c: 2, type: "note", notes: [1, 6] },
+      { r: 5, c: 5, type: "note", notes: [5] },
+    ]);
+
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      puzzle,
+      SOLUTION,
+      TARGET,
+      PLACEMENT_ONLY_HINT
+    );
+  });
+
+  it.each<{
+    label: string;
+    target: CellWithLocation;
+  }>([
+    {
+      label: "note cell with no candidates",
+      target: { r: 1, c: 1, type: "note", notes: [] },
+    },
+    {
+      label: "note cell with multiple candidates",
+      target: { r: 1, c: 1, type: "note", notes: [4, 5] },
+    },
+    {
+      label: "given",
+      target: { r: 1, c: 1, type: "given", value: 5 },
+    },
+    {
+      label: "user-entered value",
+      target: { r: 1, c: 1, type: "value", value: 5 },
+    },
+  ])("returns null when the targeted cell is a $label", ({ target }) => {
+    const puzzle =
+      target.type === "note"
+        ? withNotes(createEmptyPuzzle(BOARD_SIZE), [target])
+        : withValues(createEmptyPuzzle(BOARD_SIZE), [target]);
+
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      puzzle,
+      SOLUTION,
+      target,
+      null
+    );
+  });
+
+  it("checks only the targeted cell when another cell is an obvious single", () => {
+    const targetWithMultipleNotes: NoteCellWithLocation = {
+      r: 1,
+      c: 1,
+      type: "note",
+      notes: [4, 5],
+    };
+    const otherObviousSingle: NoteCellWithLocation = {
+      r: 0,
+      c: 0,
+      type: "note",
+      notes: [1],
+    };
+    const puzzle = withNotes(createEmptyPuzzle(BOARD_SIZE), [
+      targetWithMultipleNotes,
+      otherObviousSingle,
+    ]);
+
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      puzzle,
+      SOLUTION,
+      targetWithMultipleNotes,
+      null
+    );
+  });
+
+  it("uses the targeted obvious single when another one appears earlier on the board", () => {
+    const earlierObviousSingle: NoteCellWithLocation = {
+      r: 0,
+      c: 0,
+      type: "note",
+      notes: [1],
+    };
+    const targetedObviousSingle: NoteCellWithLocation = {
+      r: 2,
+      c: 3,
+      type: "note",
+      notes: [2],
+    };
+    const targetedValue: ValueCellWithLocation = {
+      r: 2,
+      c: 3,
+      type: "value",
+      value: 2,
+    };
+    const puzzle = withNotes(createEmptyPuzzle(BOARD_SIZE), [
+      earlierObviousSingle,
+      targetedObviousSingle,
+    ]);
+    const expectedHint: Hint = {
+      strategy: "OBVIOUS_SINGLE",
+      stages: [
+        {
+          text: "An obvious single is a cell with only one note remaining.",
+        },
+        {
+          highlightCells: [
+            { location: targetedObviousSingle, highlightType: "focus" },
+          ],
+          text: "Row 3, column 4 has only one note remaining: 2.",
+        },
+        {
+          placeValues: [targetedValue],
+          highlightCells: [
+            {
+              location: targetedValue,
+              highlightType: "placement",
+            },
+          ],
+          text: "Place 2 in row 3, column 4.",
+        },
+      ],
+    };
+
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      puzzle,
+      SOLUTION,
+      targetedObviousSingle,
+      expectedHint
+    );
+  });
+});

--- a/V4/tests/unit/obviousSingleDocs.test.ts
+++ b/V4/tests/unit/obviousSingleDocs.test.ts
@@ -1,0 +1,33 @@
+import {
+  obviousSingleHint,
+  obviousSingleNoteCell,
+  obviousSinglePuzzle,
+  simplifyingObviousSingleHint,
+  simplifyingObviousSingleNoteCell,
+  simplifyingObviousSinglePuzzle,
+} from "../../docs/OBVIOUS_SINGLE_FRONTEND_DEMO";
+import { getObviousSingleHint } from "../../obviousSingle";
+import { ADDITIONAL_TEST_BOARDS_BY_NAME } from "../utils/additionalBoards";
+import { expectHintWithoutMutation } from "../utils/assertions";
+
+describe("getObviousSingleHint OBVIOUS_SINGLE.md examples", () => {
+  it("matches the documented placement-only example exactly", () => {
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      obviousSinglePuzzle,
+      ADDITIONAL_TEST_BOARDS_BY_NAME.SINGLE_OBVIOUS_SINGLE_SOLUTION,
+      obviousSingleNoteCell,
+      obviousSingleHint
+    );
+  });
+
+  it("matches the documented placement-with-note-simplification example exactly", () => {
+    expectHintWithoutMutation(
+      getObviousSingleHint,
+      simplifyingObviousSinglePuzzle,
+      ADDITIONAL_TEST_BOARDS_BY_NAME.ONLY_OBVIOUS_SINGLES_SOLUTION,
+      simplifyingObviousSingleNoteCell,
+      simplifyingObviousSingleHint
+    );
+  });
+});


### PR DESCRIPTION
## Checklist

- [X] Update `V4/PLAN.md`

### Strategy implementation

Complete this section when the PR implements or changes a Sudoku strategy.

- [X] The strategy follows the V4 `board + context → Hint | null` interface and uses shared V4 types.
- [X] Approved docs and Frontend demo fixtures define the exact staged hint output.
- [X] Docs-contract tests reuse the demo fixtures instead of duplicating them.
- [X] Unit tests cover documented examples, additional matches, and applicable `null` cases.
- [X] Deterministic precedence and traversal order are documented and tested when multiple matches are possible.
- [X] The implementation is functional and deterministic, and tests verify that inputs are not mutated.
- [X] Strategy tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Sudoku “obvious single” hint generation, including value placement and related candidate removals.
  * Exported example note-cell fixtures for frontend demonstrations.

* **Bug Fixes**
  * Ensured hints target the selected cell and avoid duplicate candidate removals.

* **Tests**
  * Added comprehensive coverage for placement hints, peer-cell simplification, precedence, invalid targets, and documented examples.

* **Documentation**
  * Updated the V4 roadmap to mark the obvious single strategy as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->